### PR TITLE
Improve type inference performance with multiple fundeps

### DIFF
--- a/Boba.Compiler/TypeInference.fs
+++ b/Boba.Compiler/TypeInference.fs
@@ -980,7 +980,7 @@ module TypeInference =
         if List.isEmpty predList
         then DotSeq.SEnd, emptySubst
         else
-            let solved = CHR.solvePredicates fresh rules (Set.ofList predList)
+            let solved = CHR.solvePredicates fresh false rules (Set.ofList predList)
             if List.length solved > 1
             then failwith $"Non-confluent context detected, rule set should be investigated!"
             else
@@ -1004,7 +1004,7 @@ module TypeInference =
             let ctx = ctx |> DotSeq.toList |> Set.ofList
             let initial = Set.union ctx (Set.map (typeSubstExn fresh renameSubst) ctx)
             let initialEq = [typeEqConstraint unqualTy (typeSubstExn fresh renameSubst unqualTy)]
-            let reducedTest = CHR.solveConstraints fresh rules initial initialEq
+            let reducedTest = CHR.solveConstraints fresh false rules initial initialEq
             if List.length reducedTest > 1
                 then failwith $"Non-confluent context detected in ambiguity check, rule set should be investigated!"
                 else

--- a/Boba.Core.Test/CHRTests.fs
+++ b/Boba.Core.Test/CHRTests.fs
@@ -59,7 +59,7 @@ let ``Compute 'Ins ([z] -> y -> x)' ~> 'Leq (z -> z -> Bool)'`` () =
     let problem = Set.singleton (typeConstraint "Ins" [fnType (listType (valueVar "z")) (fnType (valueVar "y") (valueVar "x"))])
     let result = typeConstraint "Leq" [fnType (valueVar "z") (fnType (valueVar "z") boolType)]
     let fresh = new SimpleFresh(0)
-    let res = solvePredicates fresh leqInsRules problem
+    let res = solvePredicates fresh true leqInsRules problem
     Assert.StrictEqual(1, res.Length)
     Assert.True(isTypeMatch fresh result (fst res[0]).MaximumElement)
     Assert.True(isTypeMatch fresh (fst res[0]).MaximumElement result)
@@ -69,7 +69,7 @@ let ``Compute 'Ord ([a] -> [a] -> Bool)' ~> '' and 'Eq (a -> a -> Bool)'`` () =
     let problem = Set.singleton (typeConstraint "Ord" [fnType (listType (valueVar "a")) (fnType (listType (valueVar "a")) boolType)])
     let resultTwo = typeConstraint "Eq" [fnType (valueVar "a") (fnType (valueVar "a") boolType)]
     let fresh = new SimpleFresh(0)
-    let res = solvePredicates fresh ordEqRules problem
+    let res = solvePredicates fresh true ordEqRules problem
     Assert.StrictEqual(2, res.Length)
     Assert.StrictEqual(Set.empty, fst res[1])
     Assert.True(isTypeMatch fresh resultTwo (fst res[0]).MaximumElement)
@@ -83,7 +83,7 @@ let ``Multihead simplification 'Eq t, Leq t' ~> 'Ord t'`` () =
         |> Set.add (typeConstraint "Eq" [valueVar "a"])
     let result = typeConstraint "Ord" [valueVar "a"]
     let fresh = new SimpleFresh(0)
-    let res = solvePredicates fresh eqLeqSimplRules problem
+    let res = solvePredicates fresh true eqLeqSimplRules problem
     Assert.StrictEqual(1, res.Length)
     Assert.StrictEqual(1, Set.count (fst res[0]))
     Assert.True(isTypeMatch fresh result (fst res[0]).MaximumElement)
@@ -96,6 +96,6 @@ let ``Multihead simplification that doesnt reduce`` () =
         |> Set.add (typeConstraint "Leq" [valueVar "a"])
         |> Set.add (typeConstraint "Eq" [valueVar "b"])
     let fresh = new SimpleFresh(0)
-    let res = solvePredicates fresh eqLeqSimplRules problem
+    let res = solvePredicates fresh true eqLeqSimplRules problem
     Assert.StrictEqual(1, res.Length)
     Assert.StrictEqual(2, Set.count (fst res[0]))

--- a/test/correct-test/iterators.boba
+++ b/test/correct-test/iterators.boba
@@ -36,13 +36,6 @@ test iter-two-prints? = 0 iter-two-print is 0
 
 
 
-// TODO: hangs type inference during CHR solving, likely due to excessive confluence checking
-//test for-two-iter-map-list? =
-//    for el in [ 3, 2, 1 ] iterate, er in [ 6, 5, 4 ] iterate as list then {
-//        el er add-i32
-//    }
-//    is [ 9, 8, 7, 8, 7, 6, 7, 6, 5 ]
-
 // TODO: code generation is broken for more than one map output
 //test for-iter-map-two-list? =
 //    for el in [ 3, 2, 1 ] iterate as list, list then {

--- a/test/correct-test/multiple-fundeps.boba
+++ b/test/correct-test/multiple-fundeps.boba
@@ -1,0 +1,8 @@
+
+test for-two-iter-map-list? =
+    for el in [ 3, 2, 1 ] iterate, er in [ 6, 5, 4 ] iterate as list then {
+        el er add-inative
+    }
+    is [ 9, 8, 7, 8, 7, 6, 7, 6, 5 ]
+
+export { }


### PR DESCRIPTION
Because of how the CHR mechanism worked, it was blowing up when trying to solve constraints that contained lots of simplification rules, but might also have had some propagation rules applied.

It is still possible to hang type inference with FDs, but this will make a lot of common cases infer in a reasonable amount of time (tens of steps instead of thousands)

Resolves #65 